### PR TITLE
utils: Match all valid App IDs from systemd unit names

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,3 +1,4 @@
+be
 cs
 da
 de

--- a/po/be.po
+++ b/po/be.po
@@ -1,0 +1,185 @@
+# Belarusian translation for xdg-desktop-portal.
+# Copyright (C) 2023 xdg-desktop-portal's COPYRIGHT HOLDER
+# This file is distributed under the same license as the xdg-desktop-portal package.
+# Yuras Shumovich <shumovichy@gmail.com>, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: xdg-desktop-portal main\n"
+"Report-Msgid-Bugs-To: https://github.com/flatpak/xdg-desktop-portal/issues\n"
+"POT-Creation-Date: 2023-01-03 15:31+0000\n"
+"PO-Revision-Date: 2023-01-04 01:42+0300\n"
+"Last-Translator: Yuras Shumovich <shumovichy@gmail.com>\n"
+"Language-Team: Belarusian <i18n-bel-gnome@googlegroups.com>\n"
+"Language: be\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: src/background.c:741
+#, c-format
+msgid "Allow %s to run in the background?"
+msgstr "Дазволіць %s выкананне ў фоне?"
+
+#: src/background.c:745
+#, c-format
+msgid "%s requests to be started automatically and run in the background."
+msgstr "%s хоча атрымаць доступ на аўтаматычны запуск і выкананне ў фоне."
+
+#: src/background.c:747
+#, c-format
+msgid "%s requests to run in the background."
+msgstr "%s хоча атрымаць доступ на выкананне ў фоне."
+
+#: src/background.c:748
+msgid ""
+"The ‘run in background’ permission can be changed at any time from the "
+"application settings."
+msgstr ""
+"Дазвол на «выкананне ў фоне» заўсёды можна змяніць праз налады праграм."
+
+#: src/background.c:753
+msgid "Don't allow"
+msgstr "Не дазваляць"
+
+#: src/background.c:754 src/screenshot.c:238 src/wallpaper.c:182
+msgid "Allow"
+msgstr "Дазволіць"
+
+#: src/device.c:116
+msgid "Turn On Microphone?"
+msgstr "Уключыць мікрафон?"
+
+#: src/device.c:117
+msgid ""
+"Access to your microphone can be changed at any time from the privacy "
+"settings."
+msgstr "Доступ да мікрафона заўсёды можна змяніць праз налады прыватнасці."
+
+#: src/device.c:121
+msgid "An application wants to use your microphone."
+msgstr "Праграма хоча атрымаць доступ да мікрафона."
+
+#: src/device.c:123
+#, c-format
+msgid "%s wants to use your microphone."
+msgstr "%s хоча атрымаць доступ да мікрафона."
+
+#: src/device.c:129
+msgid "Turn On Speakers?"
+msgstr "Уключыць дынамікі?"
+
+#: src/device.c:130
+msgid ""
+"Access to your speakers can be changed at any time from the privacy settings."
+msgstr "Доступ да дынамікаў заўсёды можна змяніць праз налады прыватнасці."
+
+#: src/device.c:134
+msgid "An application wants to play sound."
+msgstr "Праграма хоча атрымаць доступ на прайграванне гуку."
+
+#: src/device.c:136
+#, c-format
+msgid "%s wants to play sound."
+msgstr "%s хоча атрымаць доступ на прайграванне гуку."
+
+#: src/device.c:142
+msgid "Turn On Camera?"
+msgstr "Уключыць камеру?"
+
+#: src/device.c:143
+msgid ""
+"Access to your camera can be changed at any time from the privacy settings."
+msgstr "Доступ да камеры заўсёды можна змяніць праз налады прыватнасці."
+
+#: src/device.c:147
+msgid "An application wants to use your camera."
+msgstr "Праграма хоча атрымаць доступ да камеры."
+
+#: src/device.c:149
+#, c-format
+msgid "%s wants to use your camera."
+msgstr "%s хоча атрымаць доступ да камеры."
+
+#: src/location.c:527
+msgid "Deny Access"
+msgstr "Забараніць доступ"
+
+#: src/location.c:529
+msgid "Grant Access"
+msgstr "Дазволіць доступ"
+
+#: src/location.c:535
+msgid "Grant Access to Your Location?"
+msgstr "Дазволіць доступ да вашага месцазнаходжання?"
+
+#: src/location.c:536
+msgid "An application wants to use your location."
+msgstr "Праграма хоча атрымаць доступ да месцазнаходжання."
+
+#: src/location.c:548
+#, c-format
+msgid "Give %s Access to Your Location?"
+msgstr "Даць %s доступ да вашага месцазнаходжання?"
+
+#: src/location.c:552
+#, c-format
+msgid "%s wants to use your location."
+msgstr "%s хоча атрымаць доступ да месцазнаходжання."
+
+#: src/location.c:555
+msgid "Location access can be changed at any time from the privacy settings."
+msgstr ""
+"Доступ да месцазнаходжанне заўсёды можна змяніць праз налады прыватнасці."
+
+#: src/screenshot.c:236 src/wallpaper.c:180
+msgid "Deny"
+msgstr "Забараніць"
+
+#: src/screenshot.c:252
+#, c-format
+msgid "Allow %s to Take Screenshots?"
+msgstr "Дазволіць %s рабіць здымкі экрана?"
+
+#: src/screenshot.c:253
+#, c-format
+msgid "%s wants to be able to take screenshots at any time."
+msgstr "%s хоча атрымаць доступ у любы час рабіць здымкі экрана."
+
+#: src/screenshot.c:261
+msgid "Allow Applications to Take Screenshots?"
+msgstr "Дазволіць праграмам рабіць здымкі экрана?"
+
+#: src/screenshot.c:262
+msgid "An application wants to be able to take screenshots at any time."
+msgstr "Праграма хоча атрымаць доступ у любы час рабіць здымкі экрана."
+
+#: src/screenshot.c:265 src/wallpaper.c:209
+msgid "This permission can be changed at any time from the privacy settings."
+msgstr ""
+"Доступ да месцазнаходжанне заўсёды можна змяніць праз налады прыватнасці."
+
+#: src/settings.c:127
+msgid "Requested setting not found"
+msgstr "Запытаная налада не знойдзена"
+
+#: src/wallpaper.c:192
+msgid "Allow Applications to Set Backgrounds?"
+msgstr "Дазволіць праграмам змяняць фон?"
+
+#: src/wallpaper.c:193
+msgid "An application is requesting to be able to change the background image."
+msgstr "Праграма запытвае доступ на змяненне фонавай выявы."
+
+#: src/wallpaper.c:205
+#, c-format
+msgid "Allow %s to Set Backgrounds?"
+msgstr "Дазволіць %s змяняць фон?"
+
+#: src/wallpaper.c:206
+#, c-format
+msgid "%s is requesting to be able to change the background image."
+msgstr "%s хоча атрымаць доступ на змяненне фонавай выявы."

--- a/po/gl.po
+++ b/po/gl.po
@@ -5,9 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: xdg-desktop-portal master\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-12 19:34-0300\n"
-"PO-Revision-Date: 2020-01-06 00:03+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/flatpak/xdg-desktop-portal/issues\n"
+"POT-Creation-Date: 2022-12-13 03:33+0000\n"
+"PO-Revision-Date: 2023-02-08 21:13+0100\n"
 "Last-Translator: Fran Diéguez <frandieguez@gnome.org>\n"
 "Language-Team: Galician\n"
 "Language: gl\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 3.2.2\n"
 
 #: src/background.c:741
 #, c-format
@@ -146,24 +146,24 @@ msgid "Deny"
 msgstr "Denegar"
 
 #: src/screenshot.c:252
-#, fuzzy, c-format
+#, c-format
 msgid "Allow %s to Take Screenshots?"
-msgstr "Permitirlle a %s configurar o fondo de pantalla?"
+msgstr "Permitirlle a %s configurar sacar capturas de pantalla?"
 
 #: src/screenshot.c:253
 #, c-format
 msgid "%s wants to be able to take screenshots at any time."
-msgstr ""
+msgstr "%s solicita poder sacar capturas de pantalla en calquer momento."
 
 #: src/screenshot.c:261
-#, fuzzy
 msgid "Allow Applications to Take Screenshots?"
-msgstr "Permitirlle ás aplicacións configurar o fondo de pantalla?"
+msgstr "Permitirlle ás aplicacións sacar capturas de pantalla?"
 
 #: src/screenshot.c:262
-#, fuzzy
 msgid "An application wants to be able to take screenshots at any time."
-msgstr "Unha aplicación quere usar o seu micrófono."
+msgstr ""
+"Unha aplicación solicita poder sacar capturas de pantalla en calquera "
+"momento."
 
 #: src/screenshot.c:265 src/wallpaper.c:209
 msgid "This permission can be changed at any time from the privacy settings."
@@ -181,7 +181,7 @@ msgstr "Permitirlle ás aplicacións configurar o fondo de pantalla?"
 
 #: src/wallpaper.c:193
 msgid "An application is requesting to be able to change the background image."
-msgstr "Unha aplicación está solicitando poder cambiar a imaxe de fondo"
+msgstr "Unha aplicación está solicitando poder cambiar a imaxe de fondo."
 
 #: src/wallpaper.c:205
 #, c-format

--- a/tests/test-xdp-utils.c
+++ b/tests/test-xdp-utils.c
@@ -147,12 +147,15 @@ test_app_id_via_systemd_unit (void)
   g_clear_pointer (&app_id, g_free);
 
   app_id = _xdp_parse_app_id_from_unit_name ("app-glib-spice\\x2dvdagent-1839.scope");
-  /* App IDs must have two periods */
-  g_assert_cmpstr (app_id, ==, "");
+  g_assert_cmpstr (app_id, ==, "spice-vdagent");
   g_clear_pointer (&app_id, g_free);
 
   app_id = _xdp_parse_app_id_from_unit_name ("app-KDE-org.kde.okular@12345.service");
   g_assert_cmpstr (app_id, ==, "org.kde.okular");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-firefox.service");
+  g_assert_cmpstr (app_id, ==, "firefox");
   g_clear_pointer (&app_id, g_free);
 
   app_id = _xdp_parse_app_id_from_unit_name ("app-org.kde.amarok.service");
@@ -169,6 +172,14 @@ test_app_id_via_systemd_unit (void)
 
   app_id = _xdp_parse_app_id_from_unit_name ("app-com.obsproject.Studio-d70acc38b5154a3a8b4a60accc4b15f4.scope");
   g_assert_cmpstr (app_id, ==, "com.obsproject.Studio");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-firefox-jcfppqx.scope");
+  g_assert_cmpstr (app_id, ==, "firefox");
+  g_clear_pointer (&app_id, g_free);
+
+  app_id = _xdp_parse_app_id_from_unit_name ("app-gnome-firefox.service");
+  g_assert_cmpstr (app_id, ==, "firefox");
   g_clear_pointer (&app_id, g_free);
 }
 #endif /* HAVE_LIBSYSTEMD */


### PR DESCRIPTION
There is no restriction to reverse DNS App IDs in the systemd spec and we don't rely on it either.